### PR TITLE
Adjust webapp chart

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: webapp
 description: A generic Helm chart to deploy any web application
-version: 0.2.0
+version: 0.3.0
 type: application
 maintainers:
 - name: sebvautour

--- a/charts/webapp/templates/_helpers.tpl
+++ b/charts/webapp/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 Expand the name of the chart.
 */}}
 {{- define "webapp.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- default .Release.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "webapp.name" . }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "webapp.labels" . | nindent 4 }}
 spec:

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -47,6 +47,9 @@ spec:
           volumeMounts:
             - name: data
               mountPath: {{ .Values.persistence.mountPath | quote }}
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -1,5 +1,14 @@
 replicaCount: 1
 
+env: []
+  # - name: SOME_CONFIG
+  #   value: value
+  # - name: SOME_SECRET_CONFIG
+  #   valueFrom:
+  #    secretKeyRef:
+  #      name: secret-name
+  #      key: secret-key
+
 image:
   repository: "todo"
   tag: "todo"
@@ -19,6 +28,8 @@ serviceAccount:
 
 podAnnotations: {}
 
+deploymentAnnotations: {}
+
 podSecurityContext: {}
   # fsGroup: 2000
 
@@ -32,7 +43,7 @@ securityContext: {}
 
 service:
   type: ClusterIP
-  port: 8080
+  port: 80
 
 containerPort: 8080
 

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -95,3 +95,4 @@ persistence:
   accessModes: []
   size: 10Gi
   mountPath: /data
+  subPath: ""


### PR DESCRIPTION
tweak webapp chart:

- add peristence.subPath value
- add support for passing env
- add support for setting deployment annotations
- adjust default service port to 80
- change name to use Release.Name