### PR TITLE
feat(charts/webapp): add support for multiple volumes and ingresses

### DIFF
--- a/charts/webapp/Chart.yaml
+++ b/charts/webapp/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: webapp
 description: A generic Helm chart to deploy any web application
-version: 0.7.0
+version: 0.8.0
 type: application
 maintainers:
 - name: sebvautour

--- a/charts/webapp/templates/deployment.yaml
+++ b/charts/webapp/templates/deployment.yaml
@@ -51,13 +51,22 @@ spec:
             {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.persistence.enabled }}
+          {{- if or .Values.persistence.enabled .Values.volumes }}
           volumeMounts:
-            - name: data
+          {{- if .Values.persistence.enabled }}
+            - name: {{ .Values.persistence.name }}
               mountPath: {{ .Values.persistence.mountPath | quote }}
               {{- if .Values.persistence.subPath }}
               subPath: {{ .Values.persistence.subPath }}
               {{- end }}
+          {{- end }}
+          {{- range .Values.volumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath | quote }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
+          {{- end }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -71,9 +80,16 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.persistence.enabled }}
+      {{- if or .Values.persistence.enabled .Values.volumes }}
       volumes:
-      - name: data
+      {{- if .Values.persistence.enabled }}
+      - name: {{ .Values.persistence.name }}
         persistentVolumeClaim:
             claimName: {{ include "webapp.pvcName" . }}
+      {{- end }}
+      {{- range .Values.volumes }}
+      - name: {{ .name }}
+        persistentVolumeClaim:
+            claimName: {{ default .claimName .existingClaim }}
+      {{- end }}
       {{- end }}

--- a/charts/webapp/templates/ingresses.yaml
+++ b/charts/webapp/templates/ingresses.yaml
@@ -1,0 +1,63 @@
+{{- $svcPort := .Values.service.port -}}
+{{- $name := include "webapp.name" . -}}
+
+{{- with .Values.ingresses }}
+---
+{{- if and .className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .annotations "kubernetes.io/ingress.class" .className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $name }}-{{ .name }}
+  labels:
+    {{- include "webapp.labels" . | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .className }}
+  {{- end }}
+  {{- if .tls }}
+  tls:
+    {{- range .tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $name }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $name }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/webapp/values.yaml
+++ b/charts/webapp/values.yaml
@@ -57,6 +57,7 @@ readinessProbe:
     path: /
     port: http
 
+# deprecated: use ingresses
 ingress:
   enabled: false
   className: ""
@@ -72,6 +73,22 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+
+ingresses: []
+  # - name: ""
+  #   className: ""
+  #   annotations: {}
+  #     # kubernetes.io/ingress.class: nginx
+  #     # kubernetes.io/tls-acme: "true"
+  #   hosts:
+  #     - host: chart-example.local
+  #       paths:
+  #         - path: /
+  #           pathType: ImplementationSpecific
+  #   tls: []
+  #   #  - secretName: chart-example-tls
+  #   #    hosts:
+  #   #      - chart-example.local
 
 resources: {}
   # limits:
@@ -94,11 +111,15 @@ tolerations: []
 
 affinity: {}
 
-# optionall can be enabled to mount a persistent volume
+
+# DEPRECATED: use volumes instead
+#
+# optional can be enabled to mount a persistent volume
 # can create a pvc with the given info or use an
 # existing one if persistence.existingClaim is set
 persistence:
   enabled: false
+  name: data
   storageClass: ""
   annotations: {}
   existingClaim: ""
@@ -107,3 +128,19 @@ persistence:
   size: 10Gi
   mountPath: /data
   subPath: ""
+
+# optional can be enabled to mount a persistent volumes.
+# can create a pvc with the given info or use an
+# existing one if persistence.existingClaim is set
+volumes: []
+  # - enabled: false
+  #   name: data
+  #   storageClass: ""
+  #   annotations: {}
+  #   claimName: ""
+  #   existingClaim: ""
+  #   accessMode: ReadWriteOnce
+  #   accessModes: []
+  #   size: 10Gi
+  #   mountPath: /data
+  #   subPath: ""


### PR DESCRIPTION
Values added:

```yaml
ingresses: []
  # - name: ""
  #   className: ""
  #   annotations: {}
  #     # kubernetes.io/ingress.class: nginx
  #     # kubernetes.io/tls-acme: "true"
  #   hosts:
  #     - host: chart-example.local
  #       paths:
  #         - path: /
  #           pathType: ImplementationSpecific
  #   tls: []
  #   #  - secretName: chart-example-tls
  #   #    hosts:
  #   #      - chart-example.local

# optional can be enabled to mount a persistent volumes.
# can create a pvc with the given info or use an
# existing one if persistence.existingClaim is set
volumes: []
  # - enabled: false
  #   name: data
  #   storageClass: ""
  #   annotations: {}
  #   claimName: ""
  #   existingClaim: ""
  #   accessMode: ReadWriteOnce
  #   accessModes: []
  #   size: 10Gi
  #   mountPath: /data
  #   subPath: ""
```